### PR TITLE
chore: rename firewall rule for internal Azure services

### DIFF
--- a/modules/azure-sql-firewall/main.tf
+++ b/modules/azure-sql-firewall/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_mssql_firewall_rule" "sql_fw_internal_service" {
-  name             = "AllowClientIP"
+  name             = "AllowInternalAzureServices"
   server_id        = var.sql_server_id
   start_ip_address = "0.0.0.0"
   end_ip_address   = "0.0.0.0"


### PR DESCRIPTION
This pull request updates the firewall rule configuration for Azure SQL in the `modules/azure-sql-firewall/main.tf` file. The change renames the firewall rule to better reflect its purpose.

Firewall rule update:

* Renamed the `azurerm_mssql_firewall_rule.sql_fw_internal_service` resource from `"AllowClientIP"` to `"AllowInternalAzureServices"` to clarify that the rule allows access from internal Azure services.